### PR TITLE
_type Attribute is now saved on inherited models.

### DIFF
--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -44,6 +44,7 @@ module Mongoid
 
           self.define_singleton_method(:inherited) do |child|
             child.tenant association, original_options
+            super(child)
           end
         end
 

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'Inheritance' do
+
+  let(:client) { Account.create!(:name => "client") }
+
+  describe "class" do
+    before do
+      Mongoid::Multitenancy.current_tenant = client
+      MutableChild.create :title => "title X", :slug => "page-x"
+    end
+    after { Mongoid::Multitenancy.current_tenant = nil }
+
+    it 'should be valid' do
+      expect(Mutable.last).to be_a MutableChild
+    end
+  end
+end


### PR DESCRIPTION
Scenario:

``` ruby
class Animal
  tenant :account
  field :name, type: String
end

class Cat < Animal
  field :age, type: Integer
end
```

When saving a `Cat` model, its `_type`-attribute was not saved to mongodb. So when calling `Animal.last` the resulting object was of type `Animal` instead of `Cat`.

Solved this by adding a call to `super` in `define_singleton_method` in the `tenant`-Method.
