### PR TITLE
Without current_tenant, tenant field shuld be allowed to be nil.

### DIFF
--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -21,7 +21,7 @@ module Mongoid
           self.tenant_field = tenant_field
 
           # Validates the tenant field
-          validates tenant_field, tenant: tenant_options
+          validates tenant_field, tenant: tenant_options, if: lambda { Multitenancy.current_tenant }
 
           # Set the current_tenant on newly created objects
           before_validation lambda { |m|

--- a/spec/mandatory_spec.rb
+++ b/spec/mandatory_spec.rb
@@ -74,8 +74,8 @@ describe Mandatory do
         item.client.should be_nil
       end
 
-      it "should be invalid" do
-        item.should_not be_valid
+      it "should be valid" do
+        item.should be_valid
       end
     end
   end


### PR DESCRIPTION
If current_tenant is not set, I need to create a new document without specifying a value to the tenant field.

Some background.
Our application/service start without multi-tenancy, personal accounts. Then we are going to introduce more strict private `team` as multi-tenancy. We need to let those personal documents live with team multi-tenancy in one application and mongo database.

`optional: true` option is not a resolution, because;
- The option does not change `validates presence` behavior, only not to set tenant field before_validation.
- In my case documents without a tenant field are not "shared" document. These documents must be excluded in queries if current_tenant is set.

I think if `current_tenant` is not set, the application must behave in the world without multi-tenancy.
