### PR TITLE
[WIP] Exclusive scope without current_tenancy

### DIFF
--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -41,7 +41,11 @@ module Mongoid
                 where({ tenant_field => Multitenancy.current_tenant.id })
               end
             else
-              where(nil)
+              if tenant_options[:optional]
+                where(nil)
+              else
+                where({ tenant_field.to_sym.exists => false })
+              end
             end
           }
 

--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -55,7 +55,7 @@ module Mongoid
           end
 
           if to_index
-            index({self.tenant_field => 1}, { background: true })
+            index({self.tenant_field => 1}, { background: true, sparse: true })
           end
         end
 

--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -21,7 +21,7 @@ module Mongoid
           self.tenant_field = tenant_field
 
           # Validates the tenant field
-          validates tenant_field, tenant: tenant_options
+          validates tenant_field, tenant: tenant_options, if: lambda { Multitenancy.current_tenant }
 
           # Set the current_tenant on newly created objects
           before_validation lambda { |m|

--- a/spec/mandatory_spec.rb
+++ b/spec/mandatory_spec.rb
@@ -74,8 +74,8 @@ describe Mandatory do
         item.client.should be_nil
       end
 
-      it "should be invalid" do
-        item.should_not be_valid
+      it "should be valid" do
+        item.should be_valid
       end
     end
   end


### PR DESCRIPTION
Assumption:
- Multitenancy may be an additional feature for already existing large data.
- We need non-multitenancy part to work as is.

Features:
- [x] tenant_fields can be nil.
- [x] Add sparse option for tenant_field indexes. This can improve index creation cost for large data.