### PR TITLE
Fixed `with_tenant` when block fails

### DIFF
--- a/lib/mongoid/multitenancy.rb
+++ b/lib/mongoid/multitenancy.rb
@@ -21,11 +21,13 @@ module Mongoid
       def with_tenant(tenant, &block)
         raise ArgumentError, 'block required' if block.nil?
 
-        old_tenant = current_tenant
-        self.current_tenant = tenant
-        result = yield
-        self.current_tenant = old_tenant
-        result
+        begin
+          old_tenant = current_tenant
+          self.current_tenant = tenant
+          yield
+        ensure
+          self.current_tenant = old_tenant
+        end
       end
     end
   end

--- a/spec/mongoid-multitenancy_spec.rb
+++ b/spec/mongoid-multitenancy_spec.rb
@@ -24,5 +24,14 @@ describe Mongoid::Multitenancy do
       Mongoid::Multitenancy.with_tenant(another_client) { ; }
       expect(Mongoid::Multitenancy.current_tenant).to eq client
     end
+
+    context 'when the block fails' do
+      it 'restores the current tenant' do
+        begin
+          Mongoid::Multitenancy.with_tenant(another_client) { raise StandardError }
+        rescue StandardError; end
+        expect(Mongoid::Multitenancy.current_tenant).to eq client
+      end
+    end
   end
 end


### PR DESCRIPTION
In `Multitenancy.with_tenant`, the old tenant wouldn't be restored if the block failed.

This PR fixes this issue, along with a test against eventual regressions.