### PR TITLE
Add mongoid 7 support

### DIFF
--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -96,7 +96,9 @@ module Mongoid
 
         # Redefine 'delete_all' to take in account the default scope
         def delete_all(conditions = nil)
-          scoped.where(conditions).delete
+          scope = scoped
+          scope = scopewhere(conditions) if conditions
+          scope.delete
         end
 
         private
@@ -154,7 +156,7 @@ module Mongoid
                 where(tenant_field => tenant_id)
               end
             else
-              where(nil)
+              all
             end
           }
 

--- a/mongoid-multitenancy.gemspec
+++ b/mongoid-multitenancy.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Mongoid::Multitenancy::VERSION
 
-  gem.add_dependency('mongoid', '~> 6', '< 8')
+  gem.add_dependency('mongoid', '~> 7')
 end


### PR DESCRIPTION
I added Moingoid 7 support and fixed the code. All specs are green!

```
Finished in 1.46 seconds (files took 1.04 seconds to load)
102 examples, 0 failures

Randomized with seed 50092

Coverage report generated for RSpec to /Users/orbanbotond/profession/ruby/mongoid-multitenancy/coverage. 552 / 552 LOC (100.0%) covered.
[Coveralls] Outside the CI environment, not sending data.
~/p/ru/mongoid-multitenancy transition-to-moingoid-7 ❯     
```