### PR TITLE
index level option :full_index for controlling the inclusion of the tenant id in the index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :test do
-  gem 'database_cleaner'
+  gem 'database_cleaner-mongoid'
   gem 'coveralls', require: false
   gem 'rspec', '~> 3.1'
   gem 'yard'

--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ end
 Mongoid indexes
 -------------------
 
-mongoid-multitenancy automatically adds the tenant foreign key in all your mongoid indexes to avoid to redefine all your validators. If you prefer to define manually the indexes, you can use the option `full_indexes: false`.
+mongoid-multitenancy automatically adds the tenant foreign key in all your mongoid indexes to avoid to redefine all your validators. If you prefer to define the indexes manually, you can use the option `full_indexes: false` on the tenant or `full_index: true/false` on the indexes.
 
 To create a single index on the tenant field, you can use the option `index: true` like any `belongs_to` declaration (false by default)
 
-On the example below, only one indexe will be created:
+On the example below, only one index will be created:
 
-* { 'title_id' => 1, 'tenant_id' => 1 }
+* { 'tenant_id' => 1, 'title' => 1 }
 
 ```ruby
 class Article
@@ -250,10 +250,11 @@ class Article
 end
 ```
 
-On the example below, 2 indexes will be created:
+On the example below, 3 indexes will be created:
 
 * { 'tenant_id' => 1 }
-* { 'title_id' => 1 }
+* { 'tenant_id' => 1, 'title' => 1 }
+* { 'name' => 1 }
 
 ```ruby
 class Article
@@ -263,8 +264,10 @@ class Article
   tenant :tenant, index: true
 
   field :title
+  field :name
 
   index({ :title => 1 })
+  index({ :name => 1 }, { full_index: false })
 end
 ```
 

--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -87,7 +87,7 @@ module Mongoid
 
         # Redefine 'index' to include the tenant field in first position
         def index(spec, options = nil)
-          super_options = options.dup || {}
+          super_options = (options || {}).dup
           full_index = super_options.delete(:full_index)
           if full_index.nil? ? tenant_options[:full_indexes] : full_index
             spec = { tenant_field => 1 }.merge(spec)

--- a/lib/mongoid/multitenancy/document.rb
+++ b/lib/mongoid/multitenancy/document.rb
@@ -87,11 +87,13 @@ module Mongoid
 
         # Redefine 'index' to include the tenant field in first position
         def index(spec, options = nil)
-          if tenant_options[:full_indexes]
+          super_options = options.dup || {}
+          full_index = super_options.delete(:full_index)
+          if full_index.nil? ? tenant_options[:full_indexes] : full_index
             spec = { tenant_field => 1 }.merge(spec)
           end
 
-          super(spec, options)
+          super(spec, super_options)
         end
 
         # Redefine 'delete_all' to take in account the default scope

--- a/spec/indexable_spec.rb
+++ b/spec/indexable_spec.rb
@@ -9,27 +9,62 @@ describe 'tenant' do
     Mongoid::Multitenancy.current_tenant = client
   end
 
-  context 'without index: true' do
-    it 'does not create an index' do
-      expect(Immutable).not_to have_index_for(tenant_id: 1)
+  describe 'tenant full_indexes option' do
+    context 'without index option' do
+      it 'does not create an index' do
+        expect(IndexableWithoutIndex).not_to have_index_for(tenant_id: 1)
+      end
+    end
+
+    context 'with index: false' do
+      it 'does not create an index' do
+        expect(IndexableWithIndexFalse).not_to have_index_for(tenant_id: 1)
+      end
+    end
+
+    context 'with index: true' do
+      it 'creates an index' do
+        expect(IndexableWithIndexTrue).to have_index_for(tenant_id: 1)
+      end
     end
   end
 
-  context 'with index: true' do
-    it 'creates an index' do
-      expect(Indexable).to have_index_for(tenant_id: 1)
-    end
-  end
+  describe 'index full_index option' do
+    context 'without tenant full_indexes option specified' do
+      it 'adds the tenant field on each index' do
+        expect(IndexableWithoutFullIndexes).to have_index_for(tenant_id: 1, title: 1)
+      end
 
-  context 'with full_indexes: true' do
-    it 'add the tenant field on each index' do
-      expect(Immutable).to have_index_for(tenant_id: 1, title: 1)
-    end
-  end
+      it 'adds the tenant field on the index with full_index: true' do
+        expect(IndexableWithoutFullIndexes).to have_index_for(tenant_id: 1, name: 1)
+      end
 
-  context 'with full_indexes: false' do
-    it 'does not add the tenant field on each index' do
-      expect(Indexable).not_to have_index_for(tenant_id: 1, title: 1)
+      it 'does not add the tenant field on the index with full_index: false' do
+        expect(IndexableWithoutFullIndexes).not_to have_index_for(tenant_id: 1, slug: 1)
+        expect(IndexableWithoutFullIndexes).to have_index_for(slug: 1)
+      end
+    end
+
+    context 'with full_indexes: true' do
+      it 'adds the tenant field on each index' do
+        expect(IndexableWithFullIndexesTrue).to have_index_for(tenant_id: 1, title: 1)
+      end
+
+      it 'does not add the tenant field on the index with full_index: false' do
+        expect(IndexableWithFullIndexesTrue).not_to have_index_for(tenant_id: 1, name: 1)
+        expect(IndexableWithFullIndexesTrue).to have_index_for(name: 1)
+      end
+    end
+
+    context 'with full_indexes: false' do
+      it 'does not add the tenant field on each index' do
+        expect(IndexableWithFullIndexesFalse).not_to have_index_for(tenant_id: 1, title: 1)
+        expect(IndexableWithFullIndexesFalse).to have_index_for(title: 1)
+      end
+
+      it 'does add the tenant field on the index with full_index: true' do
+        expect(IndexableWithFullIndexesFalse).to have_index_for(tenant_id: 1, name: 1)
+      end
     end
   end
 end

--- a/spec/models/indexable.rb
+++ b/spec/models/indexable.rb
@@ -1,10 +1,61 @@
-class Indexable
+class IndexableWithoutIndex
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  tenant :tenant, class_name: 'Account'
+end
+
+class IndexableWithIndexTrue
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  tenant :tenant, class_name: 'Account', index: true
+end
+
+class IndexableWithIndexFalse
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  tenant :tenant, class_name: 'Account', index: false
+end
+
+class IndexableWithoutFullIndexes
   include Mongoid::Document
   include Mongoid::Multitenancy::Document
 
   field :title, type: String
+  field :name, type: String
+  field :slug, type: String
 
-  tenant :tenant, class_name: 'Account', index: true, full_indexes: false
+  tenant :tenant, class_name: 'Account'
 
   index(title: 1)
+  index({ name: 1 }, { full_index: true })
+  index({ slug: 1 }, { full_index: false })
+end
+
+class IndexableWithFullIndexesFalse
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  field :title, type: String
+  field :name, type: String
+
+  tenant :tenant, class_name: 'Account', full_indexes: false
+
+  index(title: 1)
+  index({ name: 1 }, { full_index: true })
+end
+
+class IndexableWithFullIndexesTrue
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  field :title, type: String
+  field :name, type: String
+
+  tenant :tenant, class_name: 'Account', full_indexes: true
+
+  index(title: 1)
+  index({ name: 1 }, { full_index: false })
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ MODELS = File.join(File.dirname(__FILE__), 'models')
 
 require 'simplecov'
 require 'coveralls'
-require 'database_cleaner'
+require 'database_cleaner-mongoid'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
Added a boolean option :full_index to the index declaration, which when supplied will override the tenant level :full_indexes option. This allows turning off tenant id inclusion for a specific index when the inclusion is preferred for the majority of the indexes.

Example:

```
  index({ 'user_files.storage_key' => 1 }, { sparse: 1, full_index: false })
```