### PR TITLE
Fix uniqueness validator when used with conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ class Article
 end
 ```
 
+TenantUniqueness validator also allow to specify additional `conditions` to limit the uniqueness of the constraint.
+
+```ruby
+class Article
+  include Mongoid::Document
+  include Mongoid::Multitenancy::Document
+
+  tenant :tenant, optional: true
+
+  field :title
+  field :slug
+
+  validates_tenant_uniqueness_of :slug, exclude_shared: true, conditions: -> { ne(title: nil) }
+end
+```
+
 Mongoid indexes
 -------------------
 

--- a/lib/mongoid/multitenancy/validators/tenant_uniqueness.rb
+++ b/lib/mongoid/multitenancy/validators/tenant_uniqueness.rb
@@ -37,7 +37,7 @@ module Mongoid
 
         # <<Add the tenant Criteria>>
         criteria = with_tenant_criterion(criteria, klass, document)
-        criteria = criteria.merge(options[:conditions].call) if options[:conditions]
+        criteria = criteria.merge(options[:conditions].call.unscoped) if options[:conditions]
 
         if criteria.read(mode: :primary).exists?
           add_error(document, attribute, value)

--- a/spec/models/optional_exclude.rb
+++ b/spec/models/optional_exclude.rb
@@ -7,7 +7,7 @@ class OptionalExclude
   field :slug, type: String
   field :title, type: String
 
-  validates_tenant_uniqueness_of :slug, exclude_shared: true
+  validates_tenant_uniqueness_of :slug, exclude_shared: true, conditions: -> { ne(title: nil) }
   validates_presence_of :slug
   validates_presence_of :title
 


### PR DESCRIPTION
When using both `exclude_shared` and `conditions` on the Uniqueness validator, the `conditions` criteria come with the `default_scope` which can re-merge the scope, which is unexpected and can create issues.
For example, merging scope of optional which will prevent saving a model instance matching the scope: `where(tenant_field.in => [tenant_id, nil])`
See updated test model. 